### PR TITLE
Deprecated Fpart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 0.3.0 (unreleased)
+
+### Added
+
+### Changed
+
+### Deprecated
+
+- Deprecate `Fpart` - renamed `Fsegment` and available since `0.2.2`.
+
+### Fixed
+
+### Removed
+
 ## 0.2.2 (2024-10-15)
 
 ### Added

--- a/lib/fpath_base/src/fpath_base.mli
+++ b/lib/fpath_base/src/fpath_base.mli
@@ -39,5 +39,6 @@ module Fsegment : sig
 end
 
 (** This alias is kept for backward compatibility for now but will soon be
-    deprecated. Please upgrade code to [Fsegment]. *)
+    removed. Please upgrade code to [Fsegment]. *)
 module Fpart = Fsegment
+[@@ocaml.deprecated "[since 2024-10] Use Fsegment instead"]

--- a/lib/fpath_base/test/test__relative_path.ml
+++ b/lib/fpath_base/test/test__relative_path.ml
@@ -105,11 +105,11 @@ let%expect_test "append" =
 
 let%expect_test "extend" =
   let rel = Relative_path.v in
-  let file str = str |> Fpart.v in
+  let file str = str |> Fsegment.v in
   let test a b = print_s [%sexp (Relative_path.extend a b : Relative_path.t)] in
-  require_does_raise [%here] (fun () : Fpart.t -> file "a/b");
+  require_does_raise [%here] (fun () : Fsegment.t -> file "a/b");
   [%expect {| (Invalid_argument "a/b: invalid file segment") |}];
-  require_does_not_raise [%here] (fun () -> ignore (file ".." : Fpart.t));
+  require_does_not_raise [%here] (fun () -> ignore (file ".." : Fsegment.t));
   [%expect {| |}];
   test Relative_path.empty (file "a");
   [%expect {| a |}];
@@ -155,7 +155,7 @@ let%expect_test "parent" =
 
 let%expect_test "of_list" =
   let test files =
-    let result = Relative_path.of_list (List.map files ~f:Fpart.v) in
+    let result = Relative_path.of_list (List.map files ~f:Fsegment.v) in
     print_s [%sexp (result : Relative_path.t)]
   in
   test [];

--- a/lib/fpath_sexp0/src/fpath_sexp0.mli
+++ b/lib/fpath_sexp0/src/fpath_sexp0.mli
@@ -11,5 +11,6 @@ module Relative_path = Path.Relative_path
 module Fsegment = Fsegment
 
 (** This alias is kept for backward compatibility for now but will soon be
-    deprecated. Please upgrade code to [Fsegment]. *)
+    removed. Please upgrade code to [Fsegment]. *)
 module Fpart = Fsegment
+[@@ocaml.deprecated "[since 2024-10] Use Fsegment instead"]


### PR DESCRIPTION
### Deprecated

- Deprecate `Fpart` - renamed `Fsegment` and available since `0.2.2`.
