### PR TITLE
Conditional implicit transitive deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
+      # Setting `(implicit_transitive_deps VALUE)` conditionally based on the compiler version.
+      - name: Edit dune-project
+        run: opam exec -- ocaml .github/workflows/edit_dune_project_dot_ml "${{ matrix.ocaml-compiler }}"
+
       - name: Install dependencies
         run: opam install . --deps-only --with-doc --with-test --with-dev-setup
 
@@ -54,6 +58,11 @@ jobs:
           BISECT_DIR: ${{ runner.temp }}/_bisect_ppx_data
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_NUMBER: ${{ github.event.number }}
+
+      # Before checking for uncommitted changes we need to restore changes
+      # potentially made to the dune-project file.
+      - name: Restore dune-project
+        run: git restore dune-project
 
       - name: Check for uncommitted changes
         run: git diff --exit-code

--- a/.github/workflows/edit_dune_project_dot_ml
+++ b/.github/workflows/edit_dune_project_dot_ml
@@ -1,0 +1,73 @@
+(* Usage: ocaml .github/workflows/edit_dune_project_dot_ml <ocaml-version> *)
+
+let starts_with s prefix =
+  let len_s = String.length s in
+  let len_p = String.length prefix in
+  len_s >= len_p && String.sub s 0 len_p = prefix
+;;
+
+let is_implicit_transitive_deps_line line =
+  let prefix = "(implicit_transitive_deps" in
+  starts_with (String.trim line) prefix
+;;
+
+let () =
+  let usage () =
+    Printf.eprintf
+      "Error: OCaml version argument required. Usage: %s <ocaml-version>\n"
+      Sys.argv.(0);
+    exit 1
+  in
+  if Array.length Sys.argv < 2 then usage ();
+  let version = Sys.argv.(1) in
+  let dune_project = "dune-project" in
+  let file_lines =
+    try
+      let ic = open_in dune_project in
+      let rec loop acc =
+        match input_line ic with
+        | line -> loop (line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      let lines = loop [] in
+      close_in ic;
+      lines
+    with
+    | Sys_error _ ->
+      Printf.eprintf "File not found: %s\n" dune_project;
+      exit 1
+  in
+  let major, minor =
+    try
+      match String.split_on_char '.' version with
+      | major :: minor :: _ -> int_of_string major, int_of_string minor
+      | _ -> failwith "Invalid version format"
+    with
+    | _ ->
+      Printf.eprintf "Invalid OCaml version: %s\n" version;
+      exit 1
+  in
+  let should_be_false = major > 5 || (major = 5 && minor >= 2) in
+  let changed = ref false in
+  let new_lines =
+    List.map
+      (fun line ->
+         if is_implicit_transitive_deps_line line
+         then (
+           changed := true;
+           Printf.sprintf
+             "(implicit_transitive_deps %s)"
+             (if should_be_false then "false" else "true"))
+         else line)
+      file_lines
+  in
+  if !changed
+  then (
+    let oc = open_out dune_project in
+    List.iter
+      (fun l ->
+         output_string oc l;
+         output_char oc '\n')
+      new_lines;
+    close_out oc)
+;;

--- a/.github/workflows/more-ci.yml
+++ b/.github/workflows/more-ci.yml
@@ -51,13 +51,9 @@ jobs:
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
-      # This construct is not well supported by older OCaml versions. Given that
-      # we already check the build with this option in the main CI job, we
-      # disable it here unconditionally for simplicity.
+      # Setting `(implicit_transitive_deps VALUE)` conditionally based on the compiler version.
       - name: Edit dune-project
-        shell: pwsh
-        run: |
-          (Get-Content dune-project) -notmatch '\(implicit_transitive_deps false\)' | Set-Content dune-project
+        run: opam exec -- ocaml .github/workflows/edit_dune_project_dot_ml "${{ matrix.ocaml-compiler }}"
 
       # We build and run tests for a subset of packages. More tests are run in
       # the development workflow and as part of the main CI job. These are the

--- a/.github/workflows/ocaml-4-ci.yml
+++ b/.github/workflows/ocaml-4-ci.yml
@@ -40,11 +40,7 @@ jobs:
 
       # Setting `(implicit_transitive_deps VALUE)` conditionally based on the compiler version.
       - name: Edit dune-project
-        shell: bash
-        run: |
-          set -e
-          cd "$GITHUB_WORKSPACE"
-          opam exec -- ocaml .github/workflows/edit_dune_project_dot_ml "${{ matrix.ocaml-compiler }}"
+        run: opam exec -- ocaml .github/workflows/edit_dune_project_dot_ml "${{ matrix.ocaml-compiler }}"
 
       # We build and run tests for a subset of packages. More tests are run in
       # the development workflow and as part of the main CI job. These are the

--- a/.github/workflows/ocaml-4-ci.yml
+++ b/.github/workflows/ocaml-4-ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           set -e
           cd "$GITHUB_WORKSPACE"
-          opam exec -- ocaml .github/workflows/edit_dune_project.ml "${{ matrix.ocaml-compiler }}"
+          opam exec -- ocaml .github/workflows/edit_dune_project_dot_ml "${{ matrix.ocaml-compiler }}"
 
       # We build and run tests for a subset of packages. More tests are run in
       # the development workflow and as part of the main CI job. These are the

--- a/.github/workflows/ocaml-4-ci.yml
+++ b/.github/workflows/ocaml-4-ci.yml
@@ -38,13 +38,13 @@ jobs:
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
-      # This construct is not well supported by older OCaml versions. Given that
-      # we already check the build with this option in the main CI job, we
-      # disable it here unconditionally for simplicity.
+      # Setting `(implicit_transitive_deps VALUE)` conditionally based on the compiler version.
       - name: Edit dune-project
-        shell: pwsh
+        shell: bash
         run: |
-          (Get-Content dune-project) -notmatch '\(implicit_transitive_deps false\)' | Set-Content dune-project
+          set -e
+          cd "$GITHUB_WORKSPACE"
+          opam exec -- ocaml .github/workflows/edit_dune_project.ml "${{ matrix.ocaml-compiler }}"
 
       # We build and run tests for a subset of packages. More tests are run in
       # the development workflow and as part of the main CI job. These are the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.3.1 (2025-05-26)
+
+### Changed
+
+- Conditional set implicit transitive deps in CI depending on the compiler version (#15, @mbarbin).
+
 ## 0.3.0 (2025-05-15)
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,13 @@
 
 ### Changed
 
-- Conditional set implicit transitive deps in CI depending on the compiler version (#15, @mbarbin).
+- Conditional set implicit transitive deps in CI depending on the compiler version (#16, @mbarbin).
 
 ## 0.3.0 (2025-05-15)
 
 ### Added
 
+- Add ocamlmig annotations for deprecated parts (#15, @mbarbin).
 - Add support for OCaml-4.14 to `fpath-sexp0` (#14, @mbarbin).
 
 ### Deprecated

--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,17 @@
 
 (documentation "https://mbarbin.github.io/fpath-base/")
 
-(implicit_transitive_deps false)
+;; The value for the [implicit_transtive_deps] option is set during the CI
+;; depending on the OCaml compiler version.
+;;
+;; This will be set to [false] iif [ocaml-version >= 5.2].
+;;
+;; For packaging purposes with older ocaml, it is simpler atm if the option is
+;; set to [true] in the main branch.
+;;
+;; See: [.github/workflows/edit_dune_project.ml].
+
+(implicit_transitive_deps true)
 
 (package
  (name fpath-base)

--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,7 @@
 ;; For packaging purposes with older ocaml, it is simpler atm if the option is
 ;; set to [true] in the main branch.
 ;;
-;; See: [.github/workflows/edit_dune_project.ml].
+;; See: [.github/workflows/edit_dune_project_dot_ml].
 
 (implicit_transitive_deps true)
 


### PR DESCRIPTION
The value for `dune-project`'s `implicit_transtive_deps` option will now be set during the CI depending on the OCaml compiler version.

This will be set to `false` iif `ocaml-version >= 5.2`.

For packaging purposes with older ocaml, it is simpler atm if the option is set to `true` in the main branch.